### PR TITLE
docs: add droplnk.app backlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ A simple web app for previewing images in a 3x3 Instagram-style grid.
 ## Usage
 
 Open `index.html` in your browser and click on any slot to upload an image. Use the clear button to remove all images from the grid.
+
+---
+
+## Quick file sharing
+
+Learn how to quickly share files locally and remotely: [droplnk.app](https://droplnk.app) · [droplnk.app/s/](https://droplnk.app/s/)


### PR DESCRIPTION
Adds a quick file sharing section linking to https://droplnk.app and https://droplnk.app/s/ at the bottom of the README.